### PR TITLE
Fix scripts/bin link

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "rootDir": "test"
   },
   "bin": {
-    "sass-module-types": "./lib/sass-module-types"
+    "sass-module-types": "./lib/sass-module-types.js"
   },
   "devDependencies": {
     "typed-css-modules": "^0.3.7"


### PR DESCRIPTION
This fixes the script link for Windows. I've tested it using `npm link`:

```
C:\Dev\proj>npm link @babakness/sass-module-types
C:\Dev\proj\node_modules\@babakness\sass-module-types -> C:\Users\ROYSTONShufflebotham\AppData\Roaming\npm\node_modules\@babakness\sass-module-types -> C:\Dev\sass-module-types
C:\Dev\proj>node_modules\.bin\sass-module-types.cmd --help
Usage: sass-module-types [options]

Options:
  -V, --version               output the version number
  -b, --base <path>           default base is ./src/**
  -i, --sass-include <paths>  list of paths to includedefault is src/
  -p, --pattern <pattern>     default pattern is *.module.scss
  -k, --includeIndexKeys      enable index look ups on default export (disabled by default)
  -h, --help                  output usage information
```
